### PR TITLE
Header customization

### DIFF
--- a/addon/components/guidemaker-header.hbs
+++ b/addon/components/guidemaker-header.hbs
@@ -1,0 +1,17 @@
+<header class="header">
+  <nav aria-label="main" class="container">
+    <a href={{root-url "/"}} class="logo">
+      {{#if this.guidemaker.logo}}
+        <img src={{this.guidemaker.logo}} alt="" role="presentation" />
+      {{else}}
+        <span>
+          {{this.guidemaker.title}}
+        </span>
+      {{/if}}
+    </a>
+    <span>{{this.guidemaker.description}}</span>
+    <form>
+      <SearchInput projectVersion={{this.page.currentVersion}} />
+    </form>
+  </nav>
+</header>

--- a/addon/components/guidemaker-header.js
+++ b/addon/components/guidemaker-header.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class GuidemakerHeaderComponent extends Component {
+  @service guidemaker;
+  @service page;
+}

--- a/addon/styles/_header.scss
+++ b/addon/styles/_header.scss
@@ -1,15 +1,15 @@
 .header {
-    background: rgb(42,47,51);
-    background: linear-gradient(90deg, rgba(42,47,51,1) 0%, rgba(47,60,71,1) 64%, rgba(54,59,64,1) 100%);
+    background: #e04e39;
     nav {
       display: flex;
       align-items: center;
       justify-content: space-between;
+      color: white;
       a.logo {
         display: flex;
         margin: .3em 0;
         text-decoration: none;
-        font-size: 40px;
+        font-size: 30px;
         font-family: 'Fredericka the Great', cursive;
         color: white;
 

--- a/app/components/guidemaker-header.js
+++ b/app/components/guidemaker-header.js
@@ -1,0 +1,1 @@
+export { default } from 'guidemaker-default-template/components/guidemaker-header';

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,23 +1,7 @@
 {{! template-lint-disable no-redundant-landmark-role link-rel-noopener require-valid-alt-text no-curly-component-invocation }}
 <HeadLayout />
 
-<header class="header">
-  <nav role="navigation" aria-label="main" class="container">
-    <a href={{root-url "/"}} class="logo">
-      {{#if this.guidemaker.logo}}
-        <img src={{this.guidemaker.logo}}>
-      {{else}}
-        <span>
-          {{this.guidemaker.title}}
-        </span>
-      {{/if}}
-    </a>
-
-    <form>
-      {{search-input projectVersion=this.page.currentVersion}}
-    </form>
-  </nav>
-</header>
+<GuidemakerHeader />
 
 <main class="container">
   {{outlet}}

--- a/tests/dummy/app/instance-initializers/guimaker-reopener.js
+++ b/tests/dummy/app/instance-initializers/guimaker-reopener.js
@@ -3,6 +3,7 @@ import config from 'dummy/config/environment';
 export function initialize(applicationInstance) {
   let guidemakerService = applicationInstance.lookup('service:guidemaker');
   guidemakerService.reopen({
+    description: config.guidemaker.description,
     host: config.guidemaker.host,
     mascots: config.guidemaker.mascots,
   });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -26,7 +26,7 @@ module.exports = function (environment) {
 
     guidemaker: {
       title: 'Guidemaker Ember Locale Template',
-      description: 'A Guidemaker template to translate Ember.js in any language',
+      description: 'A Guidemaker template to translate Ember.js Guides in any language',
       sourceRepo: 'https://github.com/DazzlingFugu/ember-fr-guides-source',
       host: {
         name: 'Netlify',

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -26,7 +26,7 @@ module.exports = function (environment) {
 
     guidemaker: {
       title: 'Guidemaker Ember Locale Template',
-      description: 'Guides - Built with Guidemaker',
+      description: 'A Guidemaker template to translate Ember.js in any language',
       sourceRepo: 'https://github.com/DazzlingFugu/ember-fr-guides-source',
       host: {
         name: 'Netlify',


### PR DESCRIPTION
## Features
### Header customization
- Create a `<GuidemakerHeader>` component on the same model as `<GuidemakerFooter>` to make the header entirely customizable. 
- Add a description to the `guidemaker` config for the default header
- Change the background to Ember color